### PR TITLE
feat: backend server now serves the frontend files too

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1509,6 +1509,10 @@
         "node": ">=10"
       }
     },
+    "node_modules/@nswi153-crawler/frontend": {
+      "resolved": "packages/frontend",
+      "link": true
+    },
     "node_modules/@nswi153-crawler/openapi-spec": {
       "resolved": "packages/openapi-specification",
       "link": true
@@ -5421,10 +5425,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
       "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g=="
-    },
-    "node_modules/frontend": {
-      "resolved": "packages/frontend",
-      "link": true
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",
@@ -11157,6 +11157,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@crawlee/cheerio": "^3.10.5",
+        "@nswi153-crawler/frontend": "^0.0.0",
         "@nswi153-crawler/openapi-spec": "^1.0.0",
         "body-parser": "^1.20.2",
         "express": "^4.19.2",
@@ -11179,6 +11180,7 @@
       "license": "MIT"
     },
     "packages/frontend": {
+      "name": "@nswi153-crawler/frontend",
       "version": "0.0.0",
       "dependencies": {
         "@nswi153-crawler/openapi-spec": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint:fix": "eslint . --fix",
     "build": "turbo build",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "start": "npm run -w packages/backend start"
   },
   "keywords": [],
   "author": "",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@crawlee/cheerio": "^3.10.5",
+    "@nswi153-crawler/frontend": "^0.0.0",
     "@nswi153-crawler/openapi-spec": "^1.0.0",
     "body-parser": "^1.20.2",
     "express": "^4.19.2",
@@ -20,7 +21,7 @@
     "typeorm": "0.3.20"
   },
   "scripts": {
-    "build": "rimraf ./dist && tsc -p ./tsconfig.json",
+    "build": "rimraf ./dist && tsc -p ./tsconfig.json && mkdir -p ./dist/frontend && cp -a ../frontend/dist/. ./dist/frontend",
     "dev": "ts-node -T ./src/index.ts",
     "start": "node ./dist/index.js"
   }

--- a/packages/backend/src/entity/Execution.ts
+++ b/packages/backend/src/entity/Execution.ts
@@ -19,7 +19,7 @@ export class Execution {
   record: WebsiteRecord;
 
   @Column({ type: "text", default: "waiting" })
-  status: paths["/executions/{executionId}"]["get"]["responses"]["200"]["content"]["application/json"]["status"];
+  status: paths["/api/executions/{executionId}"]["get"]["responses"]["200"]["content"]["application/json"]["status"];
 
   @Column({ default: () => "CURRENT_TIMESTAMP" })
   executionTime: Date;

--- a/packages/backend/src/entity/WebsiteRecord.ts
+++ b/packages/backend/src/entity/WebsiteRecord.ts
@@ -64,7 +64,7 @@ export class WebsiteRecord {
   @JoinColumn()
   crawledPages: CrawledPage[];
 
-  serialize(): ResponseType<"/records/{recordId}", "get"> {
+  serialize(): ResponseType<"/api/records/{recordId}", "get"> {
     const lastExecution = this.getLastExecution();
 
     return {

--- a/packages/backend/src/getServer.ts
+++ b/packages/backend/src/getServer.ts
@@ -1,11 +1,14 @@
+import path from 'path';
+
 import bodyParser from "body-parser";
-import express from "express";
+import express, { Router } from "express";
 
 import "reflect-metadata";
 import { AppDataSource } from "./data-source";
 import { getGraphQlRouter } from "./graphql/graphql";
 import { getExecutionsRouter } from "./routes/executions";
 import { getRecordsRouter } from "./routes/records";
+
 
 export async function getServer() {
   const app = express();
@@ -27,8 +30,14 @@ export async function getServer() {
 
   const orm = AppDataSource.manager;
 
-  app.use("/executions", getExecutionsRouter(orm));
-  app.use("/records", getRecordsRouter(orm));
-  app.use("/graphql", getGraphQlRouter(orm));
+  const apiRouter = Router();
+  apiRouter.use("/executions", getExecutionsRouter(orm));
+  apiRouter.use("/records", getRecordsRouter(orm));
+  apiRouter.use("/graphql", getGraphQlRouter(orm));
+
+  app.use("/api", apiRouter);
+  app.use('/assets', express.static(path.join(__dirname, 'frontend', 'assets')));
+  app.get("*", (req, res) => res.sendFile(path.join(__dirname, 'frontend', 'index.html')));
+
   return app;
 }

--- a/packages/backend/src/getServer.ts
+++ b/packages/backend/src/getServer.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from "path";
 
 import bodyParser from "body-parser";
 import express, { Router } from "express";
@@ -8,7 +8,6 @@ import { AppDataSource } from "./data-source";
 import { getGraphQlRouter } from "./graphql/graphql";
 import { getExecutionsRouter } from "./routes/executions";
 import { getRecordsRouter } from "./routes/records";
-
 
 export async function getServer() {
   const app = express();
@@ -36,8 +35,13 @@ export async function getServer() {
   apiRouter.use("/graphql", getGraphQlRouter(orm));
 
   app.use("/api", apiRouter);
-  app.use('/assets', express.static(path.join(__dirname, 'frontend', 'assets')));
-  app.get("*", (req, res) => res.sendFile(path.join(__dirname, 'frontend', 'index.html')));
+  app.use(
+    "/assets",
+    express.static(path.join(__dirname, "frontend", "assets")),
+  );
+  app.get("*", (req, res) =>
+    res.sendFile(path.join(__dirname, "frontend", "index.html")),
+  );
 
   return app;
 }

--- a/packages/backend/src/routes/executions.ts
+++ b/packages/backend/src/routes/executions.ts
@@ -8,7 +8,7 @@ export function getExecutionsRouter(orm: EntityManager) {
   const router = Router();
 
   router.route("/").get(async (req, res) => {
-    const query = req.query as QueryParamsType<"/executions", "get">;
+    const query = req.query as QueryParamsType<"/api/executions", "get">;
     const { limit = 10, offset = 0, recordId } = query;
 
     const executionRepo = orm.getRepository(Execution);
@@ -25,7 +25,7 @@ export function getExecutionsRouter(orm: EntityManager) {
       },
     });
 
-    const response: Required<ResponseType<"/executions", "get">> = {
+    const response: Required<ResponseType<"/api/executions", "get">> = {
       total,
       limit,
       offset,
@@ -46,7 +46,7 @@ export function getExecutionsRouter(orm: EntityManager) {
         return res.status(404).send();
       }
 
-      const response: ResponseType<"/executions/{executionId}", "get"> =
+      const response: ResponseType<"/api/executions/{executionId}", "get"> =
         execution.serialize();
 
       return res.status(200).json(response).send();

--- a/packages/backend/src/routes/records.ts
+++ b/packages/backend/src/routes/records.ts
@@ -15,7 +15,7 @@ export function getRecordsRouter(orm: EntityManager) {
   router
     .route("/")
     .get(async (req, res) => {
-      const query = req.query as QueryParamsType<"/records", "get">;
+      const query = req.query as QueryParamsType<"/api/records", "get">;
       const {
         limit = 10,
         offset = 0,
@@ -56,7 +56,7 @@ export function getRecordsRouter(orm: EntityManager) {
         )
         .getManyAndCount();
 
-      const response: Required<ResponseType<"/records", "get">> = {
+      const response: Required<ResponseType<"/api/records", "get">> = {
         records: records.map((r) => r.serialize()),
         total,
         limit: parseInt(limit as unknown as string, 10),
@@ -66,7 +66,7 @@ export function getRecordsRouter(orm: EntityManager) {
       return res.json(response);
     })
     .post(async (req, res) => {
-      const data: paths["/records"]["post"]["requestBody"]["content"]["application/json"] =
+      const data: paths["/api/records"]["post"]["requestBody"]["content"]["application/json"] =
         req.body;
 
       const exisitngTags = await orm.find(WebsiteRecordTag, {
@@ -109,7 +109,7 @@ export function getRecordsRouter(orm: EntityManager) {
         return res.status(404).send();
       }
 
-      const response: ResponseType<"/records/{recordId}", "get"> =
+      const response: ResponseType<"/api/records/{recordId}", "get"> =
         record.serialize();
 
       return res.status(200).json(response);
@@ -124,7 +124,7 @@ export function getRecordsRouter(orm: EntityManager) {
         return res.status(404).send();
       }
 
-      const data: paths["/records/{recordId}"]["put"]["requestBody"]["content"]["application/json"] =
+      const data: paths["/api/records/{recordId}"]["put"]["requestBody"]["content"]["application/json"] =
         req.body;
       // @ts-expect-error
       const updatedRecord = orm.merge(WebsiteRecord, record, data);

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "frontend",
+  "name": "@nswi153-crawler/frontend",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/packages/frontend/src/components/ExecutionList.tsx
+++ b/packages/frontend/src/components/ExecutionList.tsx
@@ -6,9 +6,10 @@ import { ExecutionRow } from "./ExecutionRow";
 import { PaginationBar } from "./PaginationBar";
 import { Loading, useClient } from "../utils/ApiContext";
 
-type ExecutionListProps = paths["/api/executions"]["get"]["parameters"]["query"] & {
-  pagination?: boolean;
-};
+type ExecutionListProps =
+  paths["/api/executions"]["get"]["parameters"]["query"] & {
+    pagination?: boolean;
+  };
 
 const PAGE_SIZE = 5;
 

--- a/packages/frontend/src/components/ExecutionList.tsx
+++ b/packages/frontend/src/components/ExecutionList.tsx
@@ -6,7 +6,7 @@ import { ExecutionRow } from "./ExecutionRow";
 import { PaginationBar } from "./PaginationBar";
 import { Loading, useClient } from "../utils/ApiContext";
 
-type ExecutionListProps = paths["/executions"]["get"]["parameters"]["query"] & {
+type ExecutionListProps = paths["/api/executions"]["get"]["parameters"]["query"] & {
   pagination?: boolean;
 };
 
@@ -17,7 +17,7 @@ export function ExecutionList(props: ExecutionListProps) {
 
   const [executions, setExecutions] = useState<
     Loading<
-      paths["/executions"]["get"]["responses"]["200"]["content"]["application/json"]
+      paths["/api/executions"]["get"]["responses"]["200"]["content"]["application/json"]
     >
   >({
     loading: true,
@@ -31,7 +31,7 @@ export function ExecutionList(props: ExecutionListProps) {
   useEffect(() => {
     function getExecutions() {
       api
-        ?.GET("/executions", {
+        ?.GET("/api/executions", {
           params: {
             query: {
               limit,

--- a/packages/frontend/src/components/WebsiteRecordData.tsx
+++ b/packages/frontend/src/components/WebsiteRecordData.tsx
@@ -13,7 +13,7 @@ export function WebsiteRecordData(): JSX.Element {
 
   useEffect(() => {
     api
-      ?.GET("/records/{recordId}", {
+      ?.GET("/api/records/{recordId}", {
         params: {
           path: {
             recordId: Number(id),

--- a/packages/frontend/src/components/WebsiteRecordList.tsx
+++ b/packages/frontend/src/components/WebsiteRecordList.tsx
@@ -7,9 +7,9 @@ import { RecordRow } from "./RecordRow";
 import { Loading, useClient } from "../utils/ApiContext";
 
 type WebsiteRecordListProps =
-  paths["/records"]["get"]["parameters"]["query"] & { pagination?: boolean };
+  paths["/api/records"]["get"]["parameters"]["query"] & { pagination?: boolean };
 type WebsiteRecordsResponse =
-  paths["/records"]["get"]["responses"]["200"]["content"]["application/json"];
+  paths["/api/records"]["get"]["responses"]["200"]["content"]["application/json"];
 
 export function WebsiteRecordList(props: WebsiteRecordListProps) {
   const { sort, filter, filterBy, limit, offset } = props || {};
@@ -24,7 +24,7 @@ export function WebsiteRecordList(props: WebsiteRecordListProps) {
   useEffect(() => {
     function getRecords() {
       api
-        ?.GET("/records", {
+        ?.GET("/api/records", {
           params: {
             query: {
               sort: sort ?? "url:asc",

--- a/packages/frontend/src/components/WebsiteRecordList.tsx
+++ b/packages/frontend/src/components/WebsiteRecordList.tsx
@@ -7,7 +7,9 @@ import { RecordRow } from "./RecordRow";
 import { Loading, useClient } from "../utils/ApiContext";
 
 type WebsiteRecordListProps =
-  paths["/api/records"]["get"]["parameters"]["query"] & { pagination?: boolean };
+  paths["/api/records"]["get"]["parameters"]["query"] & {
+    pagination?: boolean;
+  };
 type WebsiteRecordsResponse =
   paths["/api/records"]["get"]["responses"]["200"]["content"]["application/json"];
 

--- a/packages/frontend/src/routes/WebsiteRecord.tsx
+++ b/packages/frontend/src/routes/WebsiteRecord.tsx
@@ -12,7 +12,7 @@ export function WebsiteRecord() {
 
   const deleteRecord = useCallback(async () => {
     try {
-      await api?.DELETE("/records/{recordId}", {
+      await api?.DELETE("/api/records/{recordId}", {
         params: {
           path: {
             recordId: parseInt(recordId!, 10),
@@ -28,7 +28,7 @@ export function WebsiteRecord() {
 
   const executeRecord = useCallback(async () => {
     try {
-      await api?.POST("/records/{recordId}/run", {
+      await api?.POST("/api/records/{recordId}/run", {
         params: {
           path: {
             recordId: parseInt(recordId!, 10),

--- a/packages/frontend/src/routes/WebsiteRecords.tsx
+++ b/packages/frontend/src/routes/WebsiteRecords.tsx
@@ -33,7 +33,7 @@ export function WebsiteRecords() {
       else if (type === "days") periodicity = number * 86400;
 
       try {
-        await api?.POST("/records", {
+        await api?.POST("/api/records", {
           body: {
             url: formData.get("url") as string,
             boundaryRegEx: formData.get("regex") as string,

--- a/packages/frontend/src/utils/ApiContext.tsx
+++ b/packages/frontend/src/utils/ApiContext.tsx
@@ -3,16 +3,16 @@ import createClient from "openapi-fetch";
 import { createContext, useContext } from "react";
 
 export type WebsiteRecord = Exclude<
-  paths["/records"]["get"]["responses"]["200"]["content"]["application/json"]["records"],
+  paths["/api/records"]["get"]["responses"]["200"]["content"]["application/json"]["records"],
   undefined
 >[number];
 export type Execution = Exclude<
-  paths["/executions"]["get"]["responses"]["200"]["content"]["application/json"]["records"],
+  paths["/api/executions"]["get"]["responses"]["200"]["content"]["application/json"]["records"],
   undefined
 >[number];
 
 export type SingleWebsiteRecord =
-  paths["/records/{recordId}"]["get"]["responses"]["200"]["content"]["application/json"];
+  paths["/api/records/{recordId}"]["get"]["responses"]["200"]["content"]["application/json"];
 
 export type Loading<T> =
   | {

--- a/packages/openapi-specification/openapi.yaml
+++ b/packages/openapi-specification/openapi.yaml
@@ -15,7 +15,7 @@ tags:
     description: Record of scheduled website crawls.
 
 paths:
-  /records:
+  /api/records:
     get:
       tags:
         - website-record
@@ -116,7 +116,7 @@ paths:
         "400":
           description: Invalid input
 
-  /records/{recordId}/run:
+  /api/records/{recordId}/run:
     post:
       tags:
         - website-record
@@ -141,7 +141,7 @@ paths:
         "404":
           description: Record not found
 
-  /records/{recordId}:
+  /api/records/{recordId}:
     get:
       tags:
         - website-record
@@ -217,7 +217,7 @@ paths:
           description: Invalid ID
         "404":
           description: Record not found
-  /executions:
+  /api/executions:
     get:
       tags:
         - execution
@@ -274,7 +274,7 @@ paths:
                       $ref: "#/components/schemas/Execution"
         "404":
           description: There are no executions for this recordId
-  /executions/{executionId}:
+  /api/executions/{executionId}:
     get:
       tags:
         - execution

--- a/packages/openapi-specification/src/api-types.ts
+++ b/packages/openapi-specification/src/api-types.ts
@@ -3,7 +3,6 @@
  * Do not make direct changes to the file.
  */
 
-
 export interface paths {
   "/api/records": {
     /**
@@ -234,7 +233,6 @@ export type $defs = Record<string, never>;
 export type external = Record<string, never>;
 
 export interface operations {
-
   /**
    * Get a list of website records
    * @description Get a list of the website records currently in the database. If additional query parameters are provided, the website records are filtered by label,  tag, and/or URL, and is sorted by URL or the time of the last website crawl, in ascending or descending order. Otherwise, the list contains all the  website records and is unsorted.
@@ -247,7 +245,11 @@ export interface operations {
         /** @description Field by which the website records should be filtered. */
         filterBy?: "label" | "tags" | "url";
         /** @description Method by which the website records should be sorted. The website records can be sorted by URL or by the time of the execution of the last crawl,  in ascending or descending order. The value of the parameter should have the format \"<sorting-field>:<sorting-direction>\". */
-        sort?: "url:asc" | "url:desc" | "lastExecutionTime:asc" | "lastExecutionTime:desc";
+        sort?:
+          | "url:asc"
+          | "url:desc"
+          | "lastExecutionTime:asc"
+          | "lastExecutionTime:desc";
         /**
          * @description Number of website records to return.
          * @default 10

--- a/packages/openapi-specification/src/api-types.ts
+++ b/packages/openapi-specification/src/api-types.ts
@@ -3,8 +3,9 @@
  * Do not make direct changes to the file.
  */
 
+
 export interface paths {
-  "/records": {
+  "/api/records": {
     /**
      * Get a list of website records
      * @description Get a list of the website records currently in the database. If additional query parameters are provided, the website records are filtered by label,  tag, and/or URL, and is sorted by URL or the time of the last website crawl, in ascending or descending order. Otherwise, the list contains all the  website records and is unsorted.
@@ -16,14 +17,14 @@ export interface paths {
      */
     post: operations["addRecord"];
   };
-  "/records/{recordId}/run": {
+  "/api/records/{recordId}/run": {
     /**
      * Run a website record by ID
      * @description Run the website record from the database of existing website records whose ID matches the ID provided in the path.
      */
     post: operations["runRecord"];
   };
-  "/records/{recordId}": {
+  "/api/records/{recordId}": {
     /**
      * Get a website record by ID
      * @description Get the website record from the database of existing website records whose ID matches the ID provided in the path.
@@ -40,7 +41,7 @@ export interface paths {
      */
     delete: operations["deleteRecord"];
   };
-  "/executions": {
+  "/api/executions": {
     /** Get a list of all execution IDs. */
     get: {
       parameters: {
@@ -88,7 +89,7 @@ export interface paths {
       };
     };
   };
-  "/executions/{executionId}": {
+  "/api/executions/{executionId}": {
     /** Get a execution with a given executionId */
     get: {
       parameters: {
@@ -233,6 +234,7 @@ export type $defs = Record<string, never>;
 export type external = Record<string, never>;
 
 export interface operations {
+
   /**
    * Get a list of website records
    * @description Get a list of the website records currently in the database. If additional query parameters are provided, the website records are filtered by label,  tag, and/or URL, and is sorted by URL or the time of the last website crawl, in ascending or descending order. Otherwise, the list contains all the  website records and is unsorted.
@@ -245,11 +247,7 @@ export interface operations {
         /** @description Field by which the website records should be filtered. */
         filterBy?: "label" | "tags" | "url";
         /** @description Method by which the website records should be sorted. The website records can be sorted by URL or by the time of the execution of the last crawl,  in ascending or descending order. The value of the parameter should have the format \"<sorting-field>:<sorting-direction>\". */
-        sort?:
-          | "url:asc"
-          | "url:desc"
-          | "lastExecutionTime:asc"
-          | "lastExecutionTime:desc";
+        sort?: "url:asc" | "url:desc" | "lastExecutionTime:asc" | "lastExecutionTime:desc";
         /**
          * @description Number of website records to return.
          * @default 10

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@nswi153-crawler/openapi-spec": ["packages/openapi-specification/"]
+      "@nswi153-crawler/openapi-spec": ["packages/openapi-specification/"],
+      "@nswi153-crawler/frontend": ["packages/frontend/"]
     },
     "alwaysStrict": true,
     "strict": true,


### PR DESCRIPTION
This PR simplifies the deployment by combining the frontend application and the backend server into one executable package (the fully built backend now serves the frontend files and allows the users to access the application without running a separate frontend server).

The changes are following:
- the API paths are prepended with `/api/` to distinguish from the other served files (e.g. the frontend).
- the backend now serves the frontend files
- the backend package now depends on the frontend - this is to ensure the frontend is built first (the backend build step then copies the built frontend web app into the "serveable" directory).